### PR TITLE
build(deps): upgrade ng-ovh-responsive-popover to v5.0.0-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "stylelint-config-standard": "^18.2.0"
   },
   "peerDependencies": {
+    "@ovh-ux/ng-ovh-responsive-popover": "^5.0.0-beta.0",
     "angular": "^1.7.0",
     "angular-translate": "^2.17.0",
-    "jquery": "^2.1.3",
-    "ovh-angular-responsive-popover": "^5.0.0-alpha.0"
+    "jquery": "^2.1.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@
  * @name actionsMenu
  *
  *  @requires [pascalprecht.translate](https://github.com/angular-translate/angular-translate)
- *  @requires [ovh-angular-responsive-popover](https://github.com/ovh-ux/ovh-angular-responsive-popover)
+ *  @requires [ng-ovh-responsive-popover](https://github.com/ovh-ux/ng-ovh-responsive-popover)
  *
  * @description
  * _An actions menu gives the opportunity to group a set of actions available for a specific
@@ -18,8 +18,9 @@
  */
 
 import angular from 'angular';
+
+import '@ovh-ux/ng-ovh-responsive-popover';
 import 'angular-translate';
-import 'ovh-angular-responsive-popover';
 
 import ngOvhActionsMenuItem from './item';
 
@@ -33,9 +34,9 @@ const moduleName = 'ngOvhActionsMenu';
 
 angular
   .module(moduleName, [
-    'pascalprecht.translate',
-    'ovh-angular-responsive-popover',
     ngOvhActionsMenuItem,
+    'ngOvhResponsivePopover',
+    'pascalprecht.translate',
   ])
   .directive('actionsMenu', directive)
   .factory('ActionsMenu', factory)

--- a/src/item/index.js
+++ b/src/item/index.js
@@ -4,7 +4,7 @@
  * @name actionsMenu
  *
  *  @requires [pascalprecht.translate](https://github.com/angular-translate/angular-translate)
- *  @requires [ovh-angular-responsive-popover](https://github.com/ovh-ux/ovh-angular-responsive-popover)
+ *  @requires [ng-ovh-responsive-popover](https://github.com/ovh-ux/ng-ovh-responsive-popover)
  *
  * @description
  * _An actions menu gives the opportunity to group a set of actions available for a specific context
@@ -18,7 +18,8 @@
  */
 
 import angular from 'angular';
-import 'ovh-angular-responsive-popover';
+
+import '@ovh-ux/ng-ovh-responsive-popover';
 
 import directive from './directive';
 import factory from './factory';
@@ -27,7 +28,7 @@ const moduleName = 'ngOvhActionsMenuItem';
 
 angular
   .module(moduleName, [
-    'ovh-angular-responsive-popover',
+    'ngOvhResponsivePopover',
   ])
   .directive('actionsMenuItem', directive)
   .factory('ActionsMenuItem', factory);

--- a/yarn.lock
+++ b/yarn.lock
@@ -785,6 +785,19 @@
     rollup-pluginutils "^2.3.3"
     slash "^2.0.0"
 
+"@ovh-ux/ng-ovh-responsive-popover@^5.0.0-beta.0":
+  version "5.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-responsive-popover/-/ng-ovh-responsive-popover-5.0.0-beta.0.tgz#d3420bf15096d791c8788fda616c8386d4ff0558"
+  integrity sha512-YriSOTaSDZco97Mk3DjEQu1TbZtNzXrsZPuTnDRQHCk63dg7hXwlq3B37pTE/qhLdjJPOGhIlqcpYi8InDPXVQ==
+  dependencies:
+    "@ovh-ux/translate-async-loader" "^1.0.0"
+    jquery "^2.1.3"
+
+"@ovh-ux/translate-async-loader@^1.0.0":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/translate-async-loader/-/translate-async-loader-1.0.8.tgz#7cbdc3dfed1042f511206ff6bb9f14c33b8406ba"
+  integrity sha512-8yEhPeRTSxtEO9ODXRYZw6pzRQiV5ULCTi8mIzt39m/b9N2TcIF4ILTPsaa8xpE4npHKa/iYgL9z0HJUFi2LGQ==
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -3823,6 +3836,11 @@ jest-validate@^23.5.0:
     jest-get-type "^22.1.0"
     leven "^2.1.0"
     pretty-format "^23.6.0"
+
+jquery@^2.1.3:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
+  integrity sha1-LInWiJterFIqfuoywUUhVZxsvwI=
 
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.4.9"


### PR DESCRIPTION
## :arrow_up: Upgrade `ng-ovh-responsive-popover` to `v5.0.0-beta.0`

### Description of the Change

e641552 — build(deps): upgrade ng-ovh-responsive-popover to v5.0.0-beta.0
